### PR TITLE
rename mock for c++ example to mock_cxx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(pybind11)
 
 ## Create the Python extension module from C++ source files
-set(SOURCES libs/src_cxx/mock.cpp)
+set(SOURCES libs/src_cxx/mock_cxx.cpp)
 pybind11_add_module(mock_cxx MODULE ${SOURCES})
 
 set_target_properties(mock_cxx PROPERTIES

--- a/docs/source/src_cxx/index.rst
+++ b/docs/source/src_cxx/index.rst
@@ -4,4 +4,4 @@ C++ Package
 .. toctree::
    :maxdepth: 2
 
-   mock
+   mock_cxx

--- a/docs/source/src_cxx/mock.rst
+++ b/docs/source/src_cxx/mock.rst
@@ -1,8 +1,0 @@
-C++ Mock Module
-===============
-
-Header file: ``<libs/src_cxx/mock.hpp>``
-`[source] <https://github.com/yoctoyotta1024/GoodSciProjTemplate/blob/main/libs/src_cxx/mock.hpp>`_
-
-.. doxygenfunction:: area_circle
-   :project: src_cxx

--- a/docs/source/src_cxx/mock_cxx.rst
+++ b/docs/source/src_cxx/mock_cxx.rst
@@ -1,0 +1,11 @@
+C++ Mock Module
+===============
+
+Header file: ``<libs/src_cxx/mock_cxx.hpp>``
+`[source] <https://github.com/yoctoyotta1024/GoodSciProjTemplate/blob/main/libs/src_cxx/mock_cxx.hpp>`_
+
+.. doxygenfunction:: area_circle
+   :project: src_cxx
+
+.. doxygenfunction:: add
+   :project: src_cxx

--- a/libs/src_cxx/mock_cxx.cpp
+++ b/libs/src_cxx/mock_cxx.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2024 MPI-M, Clara Bayley
  * 
  * ----- GoodSciProjTemplate -----
- * File: mock.cpp
+ * File: mock_cxx.cpp
  * Project: src_cxx
  * Created Date: Wednesday 28th February 2024
  * Author: Clara Bayley (CB)
@@ -18,7 +18,7 @@
  */
 
 
-#include "mock.hpp"
+#include "mock_cxx.hpp"
 
 PYBIND11_MODULE(mock_cxx, m) {
     m.doc() = "pybind11 example plugin";   // optional module docstring

--- a/libs/src_cxx/mock_cxx.hpp
+++ b/libs/src_cxx/mock_cxx.hpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2024 MPI-M, Clara Bayley
  * 
  * ----- GoodSciProjTemplate -----
- * File: mock.hpp
+ * File: mock_cxx.hpp
  * Project: src_cxx
  * Created Date: Tuesday 27th February 2024
  * Author: Clara Bayley (CB)
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef LIBS_SRC_CXX_MOCK_HPP_
-#define LIBS_SRC_CXX_MOCK_HPP_
+#ifndef LIBS_SRC_CXX_MOCK_CXX_HPP_
+#define LIBS_SRC_CXX_MOCK_CXX_HPP_
 
 #include <numbers>
 #include <pybind11/pybind11.h>
@@ -52,4 +52,4 @@ inline int add(const int ii, const int jj) {
   return ii + jj;
 }
 
-#endif   // LIBS_SRC_CXX_MOCK_HPP_
+#endif   // LIBS_SRC_CXX_MOCK_CXX_HPP_


### PR DESCRIPTION
rename mock c++ to mock_cxx to make it clearer that its unrelated to mock.py