### PR TITLE
no pybind11 install in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,10 +28,6 @@ jobs:
           conda activate /usr/share/miniconda/envs/myenv
           conda info --envs
 
-      - name: Install Pybind11
-        run: |
-          git submodule add https://github.com/pybind/pybind11.git external/pybind11
-          git submodule update --init
       - name: Build Pybind11 module for C++ code
         run: |
           cmake -S ./ -B ./build


### PR DESCRIPTION
don't need to install pybind11 as submodule in CI now CMakeLists.txt uses fetch content